### PR TITLE
Use React.use() for search params

### DIFF
--- a/src/app/company/[id]/page.tsx
+++ b/src/app/company/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { Suspense, use } from 'react'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
@@ -240,9 +240,10 @@ export default function CompanyPage({
   searchParams,
 }: {
   params: { id: string }
-  searchParams: { mode?: string }
+  searchParams: Promise<{ mode?: string }>
 }) {
-  const mode = (searchParams.mode as 'user' | 'guest') || 'guest'
+  const resolvedSearchParams = use(searchParams)
+  const mode = (resolvedSearchParams.mode as 'user' | 'guest') || 'guest'
 
   return (
     <Suspense fallback={<LoadingSkeleton />}>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { Suspense, use } from 'react'
 import { CompanyCard } from '@/components/CompanyCard'
 import { Button } from '@/components/ui/Button'
 import { Card, CardContent } from '@/components/ui/Card'
@@ -134,10 +134,11 @@ function LoadingSkeleton() {
 export default function SearchPage({
   searchParams,
 }: {
-  searchParams: { q?: string; mode?: string }
+  searchParams: Promise<{ q?: string; mode?: string }>
 }) {
-  const query = searchParams.q || ''
-  const mode = (searchParams.mode as 'user' | 'guest') || 'guest'
+  const params = use(searchParams)
+  const query = params.q || ''
+  const mode = (params.mode as 'user' | 'guest') || 'guest'
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">


### PR DESCRIPTION
Unwrap `searchParams` with `React.use()` to resolve Next.js warning regarding direct property access.

---
<a href="https://cursor.com/background-agent?bcId=bc-981168b1-262d-43d9-b11f-aa3f1d4bdcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-981168b1-262d-43d9-b11f-aa3f1d4bdcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

